### PR TITLE
Remove the funding file and references to oh-my-posh

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,0 @@
-github: christitustech

--- a/Microsoft.PowerShell_profile.ps1
+++ b/Microsoft.PowerShell_profile.ps1
@@ -518,23 +518,6 @@ $scriptblock = {
 }
 Register-ArgumentCompleter -Native -CommandName dotnet -ScriptBlock $scriptblock
 
-
-# Get theme from profile.ps1 or use a default theme
-function Get-Theme {
-    if (Test-Path -Path $PROFILE.CurrentUserAllHosts -PathType leaf) {
-        $existingTheme = Select-String -Raw -Path $PROFILE.CurrentUserAllHosts -Pattern "oh-my-posh init pwsh --config"
-        if ($null -ne $existingTheme) {
-            Invoke-Expression $existingTheme
-            return
-        }
-        oh-my-posh init pwsh --config https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh/main/themes/cobalt2.omp.json | Invoke-Expression
-    } else {
-        oh-my-posh init pwsh --config https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh/main/themes/cobalt2.omp.json | Invoke-Expression
-    }
-}
-
-## Final Line to set prompt
-Get-Theme
 if (Get-Command zoxide -ErrorAction SilentlyContinue) {
     Invoke-Expression (& { (zoxide init --cmd cd powershell | Out-String) })
 } else {

--- a/README.md
+++ b/README.md
@@ -19,28 +19,6 @@ After running the script, you'll have two options for installing a font patched 
 1. Extract the `cove.zip` file.
 2. Locate and install the nerd fonts.
 
-### 2) With `oh-my-posh` (loaded automatically through the PowerShell profile script hosted on this repo):
-1. Run the command `oh-my-posh font install`
-2. A list of Nerd Fonts will appear like so:
-<pre>
-PS> oh-my-posh font install
-
-   Select font
-
-  > 0xProto
-    3270
-    Agave
-    AnonymousPro
-    Arimo
-    AurulentSansMono
-    BigBlueTerminal
-    BitstreamVeraSansMono
-
-    •••••••••
-    ↑/k up • ↓/j down • q quit • ? more</pre>
-3. With the up/down arrow keys, select the font you would like to install and press <kbd>ENTER</kbd>
-4. DONE!
-   
 ## Customize this profile
 
 **Do not make any changes to the `Microsoft.PowerShell_profile.ps1` file**, since it's hashed and automatically overwritten by any commits to this repository.

--- a/setup.ps1
+++ b/setup.ps1
@@ -99,19 +99,11 @@ else {
     }
 }
 
-# OMP Install
-try {
-    winget install -e --accept-source-agreements --accept-package-agreements JanDeDobbeleer.OhMyPosh
-}
-catch {
-    Write-Error "Failed to install Oh My Posh. Error: $_"
-}
-
 # Font Install
 Install-NerdFonts -FontName "CascadiaCode" -FontDisplayName "CaskaydiaCove NF"
 
 # Final check and message to the user
-if ((Test-Path -Path $PROFILE) -and (winget list --name "OhMyPosh" -e) -and ($fontFamilies -contains "CaskaydiaCove NF")) {
+if ((Test-Path -Path $PROFILE) -and ($fontFamilies -contains "CaskaydiaCove NF")) {
     Write-Host "Setup completed successfully. Please restart your PowerShell session to apply changes."
 } else {
     Write-Warning "Setup completed with errors. Please check the error messages above."


### PR DESCRIPTION
Remove the funding file and references to oh-my-posh.

* **Microsoft.PowerShell_profile.ps1**
  - Remove the `Get-Theme` function and its invocation.
  - Remove the `oh-my-posh` installation and configuration commands.

* **README.md**
  - Remove the section related to `oh-my-posh` installation.
  - Update the instructions to reflect the removal of `oh-my-posh`.

* **setup.ps1**
  - Remove the `oh-my-posh` installation commands.
  - Update the final check and message to the user to reflect the removal of `oh-my-posh`.

* **.github/FUNDING.yml**
  - Delete the funding file.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/bradleybullock/powershell-profile/pull/2?shareId=98c1d9a7-eb5a-4706-bafb-aa7a5695486a).